### PR TITLE
Fix method_title attribute returned null

### DIFF
--- a/src/Http/Resources/V1/Shop/Checkout/CartPaymentResource.php
+++ b/src/Http/Resources/V1/Shop/Checkout/CartPaymentResource.php
@@ -17,7 +17,7 @@ class CartPaymentResource extends JsonResource
         return [
             'id'           => $this->id,
             'method'       => $this->method,
-            'method_title' => core()->getConfigData('sales.paymentmethods.'.$this->method.'.title'),
+            'method_title' => $this->method_title,
             'created_at'   => $this->created_at,
             'updated_at'   => $this->updated_at,
         ];


### PR DESCRIPTION
Fixed method_title attribute returned null when using multiple channels. Because the CartPayment record was created in the database by using method title based on channel, so it should return the saved value instead of default method title in config section.