### PR TITLE
Fix the field method_title is null when using multiple channels

### DIFF
--- a/src/Http/Resources/V1/Shop/Checkout/CartPaymentResource.php
+++ b/src/Http/Resources/V1/Shop/Checkout/CartPaymentResource.php
@@ -10,6 +10,7 @@ class CartPaymentResource extends JsonResource
      * Transform the resource into an array.
      *
      * @param  \Illuminate\Http\Request  $request
+     *
      * @return array
      */
     public function toArray($request)
@@ -17,7 +18,7 @@ class CartPaymentResource extends JsonResource
         return [
             'id'           => $this->id,
             'method'       => $this->method,
-            'method_title' => core()->getConfigData('sales.paymentmethods.'.$this->method.'.title'),
+            'method_title' => $this->method_title,
             'created_at'   => $this->created_at,
             'updated_at'   => $this->updated_at,
         ];


### PR DESCRIPTION
Fixed an issue where the method_title attribute returned null when using multiple channels.
The CartPayment record was created in the database using the method_title based on the channel, so it should now return the saved value instead of the default method_title from the configuration section.