### PR TITLE
Add console check in GDPRController constructor

### DIFF
--- a/src/Http/Controllers/V1/Admin/Customers/GDPRController.php
+++ b/src/Http/Controllers/V1/Admin/Customers/GDPRController.php
@@ -17,6 +17,10 @@ class GDPRController extends BaseController
     public function __construct(
         protected GDPRDataRequestRepository $gdprDataRequestRepository,
     ) {
+        if (app()->runningInConsole()) {
+            return;
+        }
+
         if (! core()->getConfigData('general.gdpr.settings.enabled')) {
             abort(404);
         }


### PR DESCRIPTION
## Summary
This PR prevents the `GDPRController` from aborting when the application is running in the console.

Currently, the controller constructor always executes:

```php
if (! core()->getConfigData('general.gdpr.settings.enabled')) {
    abort(404);
}
```

Laravel's Artisan commands such as `route:list`, `route:cache`, and other console commands instantiate controllers while gathering route metadata. Since there is no HTTP request in this context, calling `abort(404)` from the constructor causes these commands to fail with a `NotFoundHttpException`.

## Solution

Skip the GDPR configuration check when the application is running in the console:

```php
if (app()->runningInConsole()) {
    return;
}

if (! core()->getConfigData('general.gdpr.settings.enabled')) {
    abort(404);
}
```

## Impact

* Fixes `php artisan route:list`
* Prevents console commands from failing due to controller instantiation
* Does not change the HTTP behavior of the GDPR endpoints
* Keeps GDPR routes inaccessible when the feature is disabled
